### PR TITLE
fix: make sure .js-bag-lookup click handler works with dynamically rendered pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,13 @@
 
 All notable changes to this plugin will be documented in this file.
 
--   requires: 4.9
--   tested: 6.9
+- requires: 4.9
+- tested: 6.9
+
+## v1.2.3 - 2026-01-19
+
+fix: make sure .js-bag-lookup click handler works with dynamically rendered buttons
+fix: make sure form submit isn't triggered on enter
 
 ## v1.2.2 - 2026-01-06
 
@@ -46,24 +51,24 @@ All notable changes to this plugin will be documented in this file.
 
 ## v1.1.0 - 2021-08-19
 
--   (chore): allow for multiple bag address fields in a form
--   (fix): add necessary authorized-check
+- (chore): allow for multiple bag address fields in a form
+- (fix): add necessary authorized-check
 
 ## v1.0.3 - 2021-07-18
 
--   (fix): remove unnecessary authorized-check
+- (fix): remove unnecessary authorized-check
 
 ## v1.0.2 - 2021-07-01
 
--   (fixed): Trying to access array offset on value of type null.
--   (chore): Upgrade php-cs-fixer, and changed config to match.
+- (fixed): Trying to access array offset on value of type null.
+- (chore): Upgrade php-cs-fixer, and changed config to match.
 
 ## v1.0.1 - 2021-03-30
 
 ### Removed
 
--   Province field
+- Province field
 
 ## v1.0.0
 
--   Add: Bag address field for GravityForms.
+- Add: Bag address field for GravityForms.

--- a/languages/owc-gravityforms-bag-address.pot
+++ b/languages/owc-gravityforms-bag-address.pot
@@ -2,7 +2,7 @@
 # This file is distributed under the GPL3.0.
 msgid ""
 msgstr ""
-"Project-Id-Version: Yard | GravityForms Bag Address 1.2.2\n"
+"Project-Id-Version: Yard | GravityForms Bag Address 1.2.3\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/gravityforms-bag-address\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"

--- a/phpstan-bootstrap.php
+++ b/phpstan-bootstrap.php
@@ -4,4 +4,4 @@ define('WPINC', 'tests/Stubs');
 define('GF_BAG_FILE', 'plugin.php');
 define('GF_BAG_SLUG', 'owc-gravityforms-bag-address');
 define('GF_BAG_ROOT_PATH', './');
-define('GF_BAG_VERSION', '1.2.2');
+define('GF_BAG_VERSION', '1.2.3');

--- a/plugin.php
+++ b/plugin.php
@@ -6,7 +6,7 @@
  * Description: Add a BAG address field to GravityForms.
  * Author: Yard | Digital Agency
  * Author URI: https://www.yard.nl
- * Version: 1.2.2
+ * Version: 1.2.3
  * License: GPL3.0
  * License URI: https://www.gnu.org/licenses/gpl-3.0.txt
  * Text Domain: owc-gravityforms-bag-address
@@ -24,7 +24,7 @@ define('GF_BAG_FILE', __FILE__);
 define('GF_BAG_SLUG', 'owc-gravityforms-bag-address');
 define('GF_BAG_LANGUAGE_DOMAIN', GF_BAG_SLUG);
 define('GF_BAG_ROOT_PATH', __DIR__);
-define('GF_BAG_VERSION', '1.2.2');
+define('GF_BAG_VERSION', '1.2.3');
 
 /**
  * Manual loaded file: the autoloader.

--- a/resources/js/bag-address.js
+++ b/resources/js/bag-address.js
@@ -40,7 +40,7 @@ jQuery(document).ready(function () {
 		}, 300);
 	});
 
-	jQuery('.js-bag-lookup').on('click', function (e) {
+	jQuery(document).on('click', '.js-bag-lookup', function (e) {
 		e.preventDefault();
 
 		var button = jQuery(this);

--- a/resources/js/bag-address.js
+++ b/resources/js/bag-address.js
@@ -40,6 +40,20 @@ jQuery(document).ready(function () {
 		}, 300);
 	});
 
+	jQuery(document).on('keydown', 'input', function(e) {
+		if (!jQuery(this).data('name')) return;
+
+		if (e.key === 'Enter' || e.keyCode === 13) {
+			e.preventDefault();
+			e.stopPropagation();
+			
+			jQuery(this)
+				.closest('.gfield')
+				.find('input.js-bag-lookup[type="button"]')
+				.click();
+		}
+	});
+
 	jQuery(document).on('click', '.js-bag-lookup', function (e) {
 		e.preventDefault();
 
@@ -47,19 +61,6 @@ jQuery(document).ready(function () {
 		var container = button.closest('.gfield');
 		var identifier = container.attr('id');
 		var isValid = inputIsValid();
-
-		jQuery('input').on('keyup', function (e) {
-			if (!jQuery(this).data('name')) {
-				return;
-			}
-
-			if (e.key === 'Enter' || e.keyCode === 13) {
-				jQuery(this)
-					.closest('.gfield')
-					.find('input[type="submit"]')
-					.click();
-			}
-		});
 
 		if (isValid === false) {
 			container

--- a/src/BAG/GravityForms/BAGAddress/BAGAddressField.php
+++ b/src/BAG/GravityForms/BAGAddress/BAGAddressField.php
@@ -222,7 +222,7 @@ class BAGAddressField extends GF_Field
                 ->setFieldText(__('Addition', 'owc-gravityforms-bag-address'))
                 ->setFieldPosition('right'),
             (new StringInput())
-                ->setContent(sprintf('<span class="ginput_right"><input type="submit" class="js-bag-lookup | bag-search-button button" value="%s"></span>', __('Search', 'owc-gravityforms-bag-address'))),
+                ->setContent(sprintf('<span class="ginput_right"><input type="button" class="js-bag-lookup | bag-search-button button" value="%s"></span>', __('Search', 'owc-gravityforms-bag-address'))),
             (new StringInput())
                 ->setContent('<div class="result" style="display:block; height: 25px"></div>'),
             (new TextInput($this, $value))


### PR DESCRIPTION
In een gepagineerde AJAX formulier triggerde de `<input type="submit"` het volledige formulier. Om dit te verhelpen:

- `<input type="submit"` veranderd naar `<input type="button">`
- On click handler veranderd naar global click die checkt op class naam
- Als bij-effect moest de "Enter" keydown handler verplaatst worden en `e.preventDefault();` toegevoegd worden